### PR TITLE
Remove deprecated request reference

### DIFF
--- a/MMM-Modulebar.js
+++ b/MMM-Modulebar.js
@@ -9,7 +9,6 @@
  * MIT Licensed.
  */
 
-//var request = require('request');
 
 Module.register("MMM-Modulebar",{
 


### PR DESCRIPTION
Removes the commented-out require('request') line flagged by the MagicMirror module analysis as deprecated.

No functional changes.