### PR TITLE
Add package.json metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "MMM-Modulebar",
+  "version": "1.0.0",
+  "description": "MagicMirror² module that adds touch buttons for showing/hiding other modules.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Snille/MMM-Modulebar.git"
+  },
+  "keywords": [
+    "magicmirror",
+    "magicmirror2",
+    "MagicMirror²",
+    "touch",
+    "ui",
+    "module"
+  ],
+  "author": "Erik Pettersson",
+  "license": "MIT"
+}


### PR DESCRIPTION
Adds a minimal package.json (metadata only) so MagicMirror module tooling can index the module and so the module analysis stops flagging missing package.json.\n\nNo functional changes.